### PR TITLE
Fixes problem finding selectors for specific generated assembly using relative addresses for selector rather than absolute.

### DIFF
--- a/source/Processors/X86Processor.m
+++ b/source/Processors/X86Processor.m
@@ -1356,6 +1356,9 @@
         return NULL;
 
     // Get at the selector.
+    if (iStack[ESI].isValid)
+        selectorAddy += iStack[ESI].value;  // add the esi register
+    
     UInt8   selType = PointerType;
     char*   selPtr  = GetPointer(selectorAddy, &selType);
 
@@ -1421,6 +1424,7 @@
         {
             if (iStack[0].isValid && !iStack[0].classPtr)
                 classNameAddy   = iStack[0].value;
+               if (iStack[ESI].isValid)  classNameAddy   += iStack[ESI].value;
         }
 
         char*   className           = NULL;
@@ -1715,7 +1719,21 @@
     switch (opcode)
     {
         // pop stack into thunk registers.
-        case 0x58:  // eax
+        case 0x5e:  // esi
+				if (inLine->prev &&
+                	(inLine->prev->info.code[0] == 0xe8) &&
+                	(*(uint32_t*)&inLine->prev->info.code[2] == 0))
+            	{
+            	    iRegInfos[REG2(opcode)] = (GPRegisterInfo){0};
+                    iRegInfos[REG2(opcode)].value = inLine->info.address;
+            	    iRegInfos[REG2(opcode)].isValid = YES;
+                    iCurrentThunk = REG2(opcode);
+            	}
+                else{
+                    iRegInfos[REG2(opcode)] = (GPRegisterInfo){0};
+                }
+            break;
+		case 0x58:  // eax
         case 0x59:  // ecx
         case 0x5a:  // edx
         case 0x5b:  // ebx
@@ -1734,7 +1752,6 @@
         // pop stack into non-thunk registers. Wipe em.
         case 0x5c:  // esp
         case 0x5d:  // ebp
-        case 0x5e:  // esi
         case 0x5f:  // edi
             iRegInfos[REG2(opcode)] = (GPRegisterInfo){0};
 


### PR DESCRIPTION
Fixes issue in i386 processor where selectors are not being found for compilers that generate assembly in which the selector is accessed from an offset of the methods $ESI register (which is set immediately after prologue) rather than an absolute address.

Signed-off-by: Scott Morrison smorr@indev.ca
